### PR TITLE
Closes #48: Adds .hcl file support.

### DIFF
--- a/grammars/terraform.cson
+++ b/grammars/terraform.cson
@@ -3,6 +3,7 @@ name: 'Terraform'
 fileTypes: [
   'tf'
   'tfvars'
+  'hcl'
 ]
 foldingStartMarker: '\\{\\s*$'
 foldingStopMarker: '^\\s*\\}'


### PR DESCRIPTION
Adds `.hcl` as part of the files that are considered written in *Terrafom*

This PR would resolve #48 